### PR TITLE
Fix staff lacking tile rectangle when picked up (fixes #2877)

### DIFF
--- a/src/windows/guest.c
+++ b/src/windows/guest.c
@@ -1207,13 +1207,11 @@ void window_guest_overview_tool_update(rct_window* w, int widgetIndex, int x, in
 
 	rct_peep* peep;
 	peep = GET_PEEP(w->number);
+
 	uint32 imageId = g_sprite_entries[peep->sprite_type].sprite_image[11].base_image;
 	imageId += w->picked_peep_frame >> 2;
 
-	int ebp = peep->tshirt_colour << 19;
-	int ecx = peep->trousers_colour << 24;
-
-	imageId |= ebp | ecx | 0xA0000000;
+	imageId |= (peep->tshirt_colour << 19) | (peep->trousers_colour << 24) | 0xA0000000;
 	RCT2_GLOBAL(RCT2_ADDRESS_PICKEDUP_PEEP_IMAGE, uint32) = imageId;
 }
 

--- a/src/windows/staff.c
+++ b/src/windows/staff.c
@@ -1096,6 +1096,22 @@ void window_staff_overview_tool_update(rct_window* w, int widgetIndex, int x, in
 	if (widgetIndex != WIDX_PICKUP)
 		return;
 
+	map_invalidate_selection_rect();
+
+	RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_FLAGS, uint16) &= ~(1 << 0);
+
+	int map_x, map_y;
+	footpath_get_coordinates_from_pos(x, y + 16, &map_x, &map_y, NULL, NULL);
+	if (map_x != (sint16)0x8000) {
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_FLAGS, uint16) |= 1;
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_TYPE, uint16) = 4;
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_A_X, sint16) = map_x;
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_B_X, sint16) = map_x;
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_A_Y, sint16) = map_y;
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_B_Y, sint16) = map_y;
+		map_invalidate_selection_rect();
+	}
+
 	RCT2_GLOBAL(RCT2_ADDRESS_PICKEDUP_PEEP_IMAGE, sint32) = -1;
 
 	int interactionType;


### PR DESCRIPTION
This changes `window_guest_overview_tool_update` and `window_staff_overview_tool_update` such that they now contain the exact same logic.
