### PR TITLE
Fixes for OpenRCT2/OpenRCT2#4147

### DIFF
--- a/OpenRCT2.xcodeproj/project.pbxproj
+++ b/OpenRCT2.xcodeproj/project.pbxproj
@@ -501,8 +501,6 @@
 		D41B74721C2125E50080A7B9 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = distribution/osx/Assets.xcassets; sourceTree = SOURCE_ROOT; };
 		D43407C01D0E14BE00C2B3D4 /* CopyFramebufferShader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CopyFramebufferShader.cpp; sourceTree = "<group>"; };
 		D43407C11D0E14BE00C2B3D4 /* CopyFramebufferShader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CopyFramebufferShader.h; sourceTree = "<group>"; };
-		D43407C21D0E14BE00C2B3D4 /* DrawImageMaskedShader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DrawImageMaskedShader.cpp; sourceTree = "<group>"; };
-		D43407C31D0E14BE00C2B3D4 /* DrawImageMaskedShader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DrawImageMaskedShader.h; sourceTree = "<group>"; };
 		D43407C41D0E14BE00C2B3D4 /* DrawImageShader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DrawImageShader.cpp; sourceTree = "<group>"; };
 		D43407C51D0E14BE00C2B3D4 /* DrawImageShader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DrawImageShader.h; sourceTree = "<group>"; };
 		D43407C61D0E14BE00C2B3D4 /* DrawLineShader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DrawLineShader.cpp; sourceTree = "<group>"; };
@@ -1297,8 +1295,6 @@
 			children = (
 				D43407C01D0E14BE00C2B3D4 /* CopyFramebufferShader.cpp */,
 				D43407C11D0E14BE00C2B3D4 /* CopyFramebufferShader.h */,
-				D43407C21D0E14BE00C2B3D4 /* DrawImageMaskedShader.cpp */,
-				D43407C31D0E14BE00C2B3D4 /* DrawImageMaskedShader.h */,
 				D43407C41D0E14BE00C2B3D4 /* DrawImageShader.cpp */,
 				D43407C51D0E14BE00C2B3D4 /* DrawImageShader.h */,
 				D43407C61D0E14BE00C2B3D4 /* DrawLineShader.cpp */,
@@ -2405,7 +2401,6 @@
 				C686F9311CDBC3B7009F9BFC /* ghost_train.c in Sources */,
 				D44272821CC81B3200D84D28 /* shortcut_key_change.c in Sources */,
 				D442722A1CC81B3200D84D28 /* localisation.c in Sources */,
-				D43407D71D0E14BE00C2B3D4 /* DrawImageMaskedShader.cpp in Sources */,
 				D44272731CC81B3200D84D28 /* new_ride.c in Sources */,
 				D442721A1CC81B3200D84D28 /* console.c in Sources */,
 				D44271FB1CC81B3200D84D28 /* ScreenshotCommands.cpp in Sources */,


### PR DESCRIPTION
When you removed DrawImageMaskedShader from the Xcode project, you removed the bare minimum to get it to compile. The project still had broken links to the DrawImageMaskedShader.cpp and DrawImageMaskedShader.h files visible in Xcode itself. I removed the files from within Xcode, which got rid of all the references.
